### PR TITLE
load atlas which contains many .png files inside, size of images of particular texture_keys

### DIFF
--- a/modules/core/kivent_core/renderers.pxd
+++ b/modules/core/kivent_core/renderers.pxd
@@ -4,6 +4,7 @@ from cpython cimport bool
 cdef class TextureManager:
     cdef dict _textures
     cdef dict _keys
+    cdef dict _sizes
     cdef dict _uvs
     cdef dict _groups
 


### PR DESCRIPTION
I have lot of images, which cannot be packed into single .png in atlas and I discovered that load_atlas supports only first image from atlas. I have fixed it (I hope it was bug not feature). 

Also, I needed to know width/height of particular texture_key, so I added get_size(txt_key) to TextureManager. 